### PR TITLE
Remove deprecated quadrupal-build package

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -82,10 +82,6 @@
             "type": "vcs",
             "url": "ssh://git@dvcs.deloittedigital.com.au:22/dru/quadrupal.git"
         },
-        "quadrupal-build": {
-            "type": "vcs",
-            "url": "ssh://git@dvcs.deloittedigital.com.au:22/dru/quadrupal-build.git"
-        },
         "drupal-project": {
             "type": "vcs",
             "url": "ssh://git@dvcs.deloittedigital.com.au:22/dru/drupal-project.git"


### PR DESCRIPTION
This project template package has been deprecated. 
Teams should use drupal-project instead.