### PR TITLE
DDDP-145: Added fork of Media Entity Soundcloud.

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -85,6 +85,10 @@
         "drupal-project": {
             "type": "vcs",
             "url": "ssh://git@dvcs.deloittedigital.com.au:22/dru/drupal-project.git"
+        },
+        "media_entity_soundcloud": {
+            "type": "vcs",
+            "url": "ssh://git@dvcs.deloittedigital.com.au:22/dru/media_entity_soundcloud.git"
         }
     },
     "require-all": true


### PR DESCRIPTION
The current release of Media Entity Soundcloud is not compatible with our Deloitte Accelerator profile; I've created a fork in our private repo and adding it to Satis so we can have a D9-compatible profile.